### PR TITLE
add python style guide

### DIFF
--- a/python-style.md
+++ b/python-style.md
@@ -1,0 +1,28 @@
+Code style for Sugar Python development
+=======================================
+
+General
+-------
+
+* Avoid lines longer than 80 characters.
+
+Python
+------
+
+* Make your code conform to pep8 and pyflakes
+
+* Use four spaces for indentation.
+
+Libraries
+---------
+
+* New code should be written using Gtk3, Gst-1.0, etc.
+
+* Use json, ...
+
+* Use sugargames when interfacing to pygames
+
+Conventions
+-----------
+
+* Methods documentation should be "attached" to the methods (See http://www.python.org/dev/peps/pep-0257)


### PR DESCRIPTION
This is a stub for adding a style guide for Python analogous to the
guide for HTML/Javascript.
