### PR TITLE
Fixes broken anchor link to "non-AMD libs" header

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -62,7 +62,7 @@ In your new activity, you will find the following file structure:
 Those are the files you'll modify in most cases. The others are:
 
 * `js/loader.js` configures the libraries paths and loads your
-  `js/activity.js` . You can add [non-AMD libraries](#non-amd-libs) here.
+  `js/activity.js` . You can add [non-AMD libraries](#non-amd%20libs) here.
 
 * `lib/` contains the libraries
 


### PR DESCRIPTION
tested with `osbuild docs`

Note: this fix breaks the link when previewing `activity.md` with github's interface...
