### PR TITLE
dev-environment: correct JSON in prefs.json github example

### DIFF
--- a/dev-environment.md
+++ b/dev-environment.md
@@ -141,7 +141,7 @@ so that remotes will be setup automatically for those. For example
     "github": {
         "forks": [
             "myname/sugar.git",
-            "myname/sugar-docs.git",
+            "myname/sugar-docs.git"
         ],
         "ssh": [
             "sugarlabs/sugar.git",


### PR DESCRIPTION
When using the example dev-environment.md's example prefs.json (github section), I get this error:

```
[sugar-build]$ ./osbuild shell
Traceback (most recent call last):
  File "./osbuild", line 494, in <module>
    main()
  File "./osbuild", line 462, in main
    if not check_lock():
  File "./osbuild", line 404, in check_lock
    fcntl.lockf(get_lock_file(), fcntl.LOCK_EX | fcntl.LOCK_NB)
  File "./osbuild", line 83, in get_lock_file
    lock_file = open(get_lock_file_path(), "w")
  File "./osbuild", line 74, in get_lock_file_path
    return os.path.join(get_base_dir(), get_name_for_mode(".lock", mode))
  File "./osbuild", line 63, in get_name_for_mode
    mode = get_mode()
  File "./osbuild", line 51, in get_mode
    if not get_prefs().get("use_broot", True):
  File "./osbuild", line 136, in get_prefs
    _prefs = json.load(f)
  File "/usr/lib64/python2.7/json/__init__.py", line 290, in load
    **kw)
  File "/usr/lib64/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python2.7/json/decoder.py", line 365, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python2.7/json/decoder.py", line 383, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

This commit / pull-request fixes that issue by removing the spurious comma from the example JSON.
