### PR TITLE
added reference to gsettings and log files

### DIFF
--- a/dev-environment.md
+++ b/dev-environment.md
@@ -201,7 +201,10 @@ language='sh'>sugar-build/home/dotsugar</code></pre>
 
 Sugar uses gsettings for a number of different settings. In the
 development environment, these settings are found in <pre><code
-language='sh'>???</code></pre>
+language='sh'>sugar-build/home/default/config/dconf</code></pre>
+
+osbuild check uses its own gsetting. These can be found in <pre><code
+language='sh'>sugar-build/home/check/config/dconf</code></pre>
 
 ### gconf (deprecated)
 


### PR DESCRIPTION
The current documentation refers to gconf, which s deprecated. I added a comment to mark it as such and left a boilerplate for gsettings.

There is also a new section that refers to where log files can be found.

Not sure where to put it, but it would be good to add more information about osbuild check (how to check the logs -- not obvious)
