### PR TITLE
remove reference to buildbot status, fix missing space

### DIFF
--- a/dev-environment.md
+++ b/dev-environment.md
@@ -34,14 +34,8 @@ Finally run sugar.
 run
 </code></pre>
 
-If anything goes wrong, you can check if there are known problems by looking
-at the
-[buildbot status](http://buildbot.sugarlabs.org/waterfall). If it's red
-then something is wrong and hopefully developers will fix it soon. If it's
-green then the issue is probably not yet known and you should report it.
-
-If you are still having problems, read the common issues section or subscribe
-to the[sugar-devel](http://lists.sugarlabs.org/listinfo/sugar-devel) mailing
+If anything goes wrong, read the common issues section or subscribe
+to the [sugar-devel](http://lists.sugarlabs.org/listinfo/sugar-devel) mailing
 list, and send an email. We will usually reply within 24 hours.
 
 Common Issues


### PR DESCRIPTION
* the broken link to buildbot status continues to deceive potential developers, so remove it.
* add a missing space before link to mailing list,

Reported-by: James Cameron on [23rd October 2015](http://lists.sugarlabs.org/archive/sugar-devel/2015-October/050910.html), nobody had fixed it since,
Reported-by: Kimberly Sookoo of RIT just today.
