### PR TITLE
Add link for the tutorial on python activities

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -277,3 +277,9 @@ With **Sugarizer**, you can directly publish the XO bundle. So, just zip the con
 
 For further releases, you should update the activity_version in
 `activity/activity.info`.
+
+Writing python activities
+===========================
+You may follow this book by James Simmons on how to make Sugar activities, available at  
+
+https://flossmanuals.net/make-your-own-sugar-activities/


### PR DESCRIPTION
As a new developer I faced this issues that I wasn't knowing
where to learn about developing python based activities, until
I was suggested this book on sugar-devel [1].
Hence I believe that the link to this great book must be here.

[1] http://lists.sugarlabs.org/archive/sugar-devel/2016-March/051600.html