### PR TITLE
Rework the Guide to Contributing

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -6,7 +6,7 @@ We use the pull-request model, see [GitHub's help on pull-request](https://help.
 In short, you will:
 
 * file an issue about what you plan to change;
-* do your changes in a new branch;
+* commit your changes in a new branch;
 * push your branch and submit a pull-request for it;
 * go through the review process until your pull-request is merged; and
 * close your issue.

--- a/contributing.md
+++ b/contributing.md
@@ -69,6 +69,11 @@ Make one or more commits and push the branch
 
 Your branch NAME can be anything, other than master.  The scope is your forked repository.  The branch name will be shown on pull-requests.
 
+### Making commits
+
+Make sure to add "Fixes #1234" to the commit message, being #1234 the number of the issue ticket related to your changes. 
+This way, the ticket may be closed automatically.
+
 ### Sending a pull-request
 
 Submit a pull-request for the branch. 
@@ -91,8 +96,6 @@ Submit the changes to another remote branch
 
 Finally submit the new pull-request on GitHub as you did before.
 
-Make sure to add "Fixes #1234" to the commit message, being #1234 the number of the issue ticket related to your changes. 
-This way, the ticket will be closed automatically.
 
 ### Keep your fork up to date
 

--- a/contributing.md
+++ b/contributing.md
@@ -99,11 +99,11 @@ Finally submit the new pull-request on GitHub as you did before.
 
 ### Keep your fork up to date
 
-Don't forget to pull in changes from the master repository that is 'upstream.' 
-To pull in upstream changes:
+When there have been upstream commits since your fork was made, you should bring these into your fork:
 
-    git fetch upstream
-    git merge upstream/master
+    git checkout master
+    git pull upstream
+    git checkout NAME
 
 ### Review
 

--- a/contributing.md
+++ b/contributing.md
@@ -57,17 +57,21 @@ Navigate to the [sugar repository](https://github.com/sugarlabs/sugar/), press *
     git remote add upstream https://github.com/sugarlabs/sugar.git
     git fetch upstream
 
-### Sending a pull-request
+### Branching
 
 Create one branch per topic
 
-    git checkout -b topic1
+    git checkout -b NAME
 
 Make one or more commits and push the branch
 
-    git push origin topic1
+    git push origin NAME
 
-Submit a pull request for the branch. 
+Your branch NAME can be anything, other than master.  The scope is your forked repository.  The branch name will be shown on pull-requests.
+
+### Sending a pull-request
+
+Submit a pull-request for the branch. 
 Navigate to your repository page in GitHub, switch to the branch you made, and then press the **Pull Request** button.
 
 After that, the review process will happen in the pull-request page on GitHub. 

--- a/contributing.md
+++ b/contributing.md
@@ -45,14 +45,14 @@ Generally, each improvement to Sugar should start with an issue discussion, to e
 
 ### Forking
 
-You should fork the repository first. 
+You should first fork the repository on GitHub. 
 This step is needed only once. 
 See [complete help in GitHub](https://help.github.com/articles/fork-a-repo). 
 Brief instructions follow using [sugar component](https://github.com/sugarlabs/sugar) as example.
 
 Navigate to the [sugar repository](https://github.com/sugarlabs/sugar/), press **Fork** button, then
 
-    git clone https://github.com/YOUR-NAME/sugar.git
+    git clone git@github.com:YOUR-NAME/sugar.git
     cd sugar
     git remote add upstream https://github.com/sugarlabs/sugar.git
     git fetch upstream

--- a/contributing.md
+++ b/contributing.md
@@ -85,7 +85,13 @@ Change files, and commit.  When writing a commit message;
 Send a pull-request for your branch. 
 Navigate to your repository page in GitHub, switch to the branch you made, and then press the **Pull Request** button.
 
-After that, a review will happen in the pull-request, and a reviewer will either;
+When writing a pull-request message;
+
+1. if there is only one commit, accept the GitHub default of the commit message, otherwise explain the series of commits,
+2. mention any relevant pull-requests,
+3. mention any relevant resources, such as issues, tickets, or competition tasks.
+
+A review will happen in the pull-request, and a reviewer will either;
 
 1. merge your commits,
 2. merge your commits with their own changes,

--- a/contributing.md
+++ b/contributing.md
@@ -96,6 +96,17 @@ Submit the changes to another remote branch
 
 Finally submit the new pull-request on GitHub as you did before.
 
+### Keep your pull-request up to date
+
+When there have been upstream commits while your pull-request was open, you should rebase your pull-request:
+
+    git pull --rebase upstream
+
+Then push the changes to the same branch
+
+    git push --force origin
+
+The pull-request will be updated.
 
 ### Keep your fork up to date
 

--- a/contributing.md
+++ b/contributing.md
@@ -76,25 +76,25 @@ This way, the ticket may be closed automatically.
 
 ### Sending a pull-request
 
-Submit a pull-request for the branch. 
+Send a pull-request for your branch. 
 Navigate to your repository page in GitHub, switch to the branch you made, and then press the **Pull Request** button.
 
-After that, the review process will happen in the pull-request page on GitHub. 
-The process ends with one of this:
+After that, a review will happen in the pull-request, and a reviewer will either;
 
-1. A reviewer merges your request.
-2. A reviewer rejects your request providing reasons (and closes the request)
-3. A reviewer requires changes (and closes the request)
+1. merge your commits,
+2. merge your commits with their own changes,
+3. ask you to make changes, or
+4. close and reject your request giving reasons.
 
-In case they ask you for changes, make them using [interactive rebase](http://git-scm.com/book/en/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages)
+When they ask you for changes, make them using [interactive rebase](http://git-scm.com/book/en/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages)
 
     git rebase -i master
 
-Submit the changes to another remote branch
+Then push the changes to the same branch
 
-    git push origin topic1:topic1-try2
+    git push --force origin
 
-Finally submit the new pull-request on GitHub as you did before.
+Then respond on the pull-request.
 
 ### Keep your pull-request up to date
 

--- a/contributing.md
+++ b/contributing.md
@@ -71,8 +71,14 @@ Your branch NAME can be anything, other than master.  The scope is your forked r
 
 ### Making commits
 
-Make sure to add "Fixes #1234" to the commit message, being #1234 the number of the issue ticket related to your changes. 
-This way, the ticket may be closed automatically.
+Change files, and commit.  When writing a commit message;
+
+1. start with a one line summary of the change,
+2. leave a blank line after the summary,
+3. explain the problem that is solved, unless the summary makes it obvious,
+4. when the problem was introduced by a previous commit, mention the hash,
+5. when the problem is in an issue ticket, add "Fixes #1234", and the ticket may be closed automatically,
+6. avoid mentioning GitHub or other pull-requests, as these are not kept in git,
 
 ### Sending a pull-request
 

--- a/contributing.md
+++ b/contributing.md
@@ -21,22 +21,6 @@ We recommend using the same process as below to develop your own Activities.
 Modifying Sugar
 ---------------
 
-Before going through the details on how to submit changes, let's look at the useful tools we provide to assist contributors in the process of modifying Sugar.
-
-If you are hacking on sugar-web, run the testsuit with the *karma* command inside a osbuild shell:
-
-    karma start sugar-web/test/karma.conf.js
-
-We encourage writting new unit tests for new features.
-
-After you do the changes, run:
-
-    check
-
-It will run all the code checks and the unit tests making sure you won't break the build when your changes are pushed. 
-If the checks doesn't succeed because of coding style, see the coding style guide [for web](web-style.md.html) or [for Python](python-style.md.html). 
-If a test doesn't pass either your code needs to be fixed or the test need to be adapted.
-
 ### Open an Issue
 
 We track issues in http://bugs.sugarlabs.org

--- a/contributing.md
+++ b/contributing.md
@@ -5,11 +5,11 @@ We use the pull-request model, see [GitHub's help on pull-request](https://help.
 
 In short, you will:
 
-* file an issue about what you plan to change
-* do your changes in a new branch
-* push your branch and submit a pull-request for it
-* go through the review process until your pull-request is merged
-* close your issue
+* file an issue about what you plan to change;
+* do your changes in a new branch;
+* push your branch and submit a pull-request for it;
+* go through the review process until your pull-request is merged; and
+* close your issue.
 
 Activity Repositories
 -----------------
@@ -57,11 +57,11 @@ Your branch NAME can be anything, other than master.  The scope is your forked r
 
 Change files, and commit.  When writing a commit message;
 
-1. start with a one line summary of the change,
-2. leave a blank line after the summary,
-3. explain the problem that is solved, unless the summary makes it obvious,
-4. when the problem was introduced by a previous commit, mention the hash,
-5. when the problem is in an issue ticket, add "Fixes #1234", and the ticket may be closed automatically,
+1. start with a one line summary of the change;
+2. leave a blank line after the summary;
+3. explain the problem that is solved, unless the summary makes it obvious;
+4. when the problem was introduced by a previous commit, mention the hash;
+5. when the problem is in an issue ticket, add "Fixes #1234", and the ticket may be closed automatically; and
 6. avoid mentioning GitHub or other pull-requests, as these are not kept in git,
 
 ### Sending a pull-request
@@ -71,15 +71,15 @@ Navigate to your repository page in GitHub, switch to the branch you made, and t
 
 When writing a pull-request message;
 
-1. if there is only one commit, accept the GitHub default of the commit message, otherwise explain the series of commits,
-2. mention any relevant pull-requests,
+1. if there is only one commit, accept the GitHub default of the commit message, otherwise explain the series of commits;
+2. mention any relevant pull-requests; and
 3. mention any relevant resources, such as issues, tickets, or competition tasks.
 
 A review will happen in the pull-request, and a reviewer will either;
 
-1. merge your commits,
-2. merge your commits with their own changes,
-3. ask you to make changes, or
+1. merge your commits;
+2. merge your commits with their own changes;
+3. ask you to make changes; or
 4. close and reject your request giving reasons.
 
 When they ask you for changes, make them using [interactive rebase](http://git-scm.com/book/en/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages)

--- a/contributing.md
+++ b/contributing.md
@@ -1,7 +1,7 @@
 Contributing
 ============
 
-We use the pull-request model, see [github's help on pull-request](https://help.github.com/articles/using-pull-requests).
+We use the pull-request model, see [GitHub's help on pull-request](https://help.github.com/articles/using-pull-requests).
 
 In short, you will:
 
@@ -14,7 +14,7 @@ In short, you will:
 Activity Repositories
 -----------------
 
-To request a new activity repo, email the http://lists.sugarlabs.org/listinfo/systems list with the name of the repo and the github usernames who should have access.
+To request a new activity repo, email the http://lists.sugarlabs.org/listinfo/systems list with the name of the repo and the GitHub usernames who should have access.
 
 We recommend using the same process as below to develop your own Activities.
 
@@ -47,7 +47,7 @@ Generally, each improvement to Sugar should start with an issue discussion, to e
 
 You should fork the repository first. 
 This step is needed only once. 
-See [complete help in github](https://help.github.com/articles/fork-a-repo). 
+See [complete help in GitHub](https://help.github.com/articles/fork-a-repo). 
 Brief instructions follow using [sugar component](https://github.com/sugarlabs/sugar) as example.
 
 Navigate to the [sugar repository](https://github.com/sugarlabs/sugar/), press **Fork** button, then
@@ -68,9 +68,9 @@ Make one or more commits and push the branch
     git push origin topic1
 
 Submit a pull request for the branch. 
-Navigate to your repository page in github, switch to the branch you made, and then press the **Pull Request** button.
+Navigate to your repository page in GitHub, switch to the branch you made, and then press the **Pull Request** button.
 
-After that, the review process will happen in the pull-request page on github. 
+After that, the review process will happen in the pull-request page on GitHub. 
 The process ends with one of this:
 
 1. A reviewer merges your request.
@@ -85,7 +85,7 @@ Submit the changes to another remote branch
 
     git push origin topic1:topic1-try2
 
-Finally submit the new pull request through the github site as you did before.
+Finally submit the new pull-request on GitHub as you did before.
 
 Make sure to add "Fixes #1234" to the commit message, being #1234 the number of the issue ticket related to your changes. 
 This way, the ticket will be closed automatically.
@@ -102,11 +102,11 @@ To pull in upstream changes:
 
 We encourage testing before merging a pull-request. 
 
-So instead of merging directly with the "merge" button on github UI, we do a local merge, then test, then push.  
+So instead of merging directly with the "merge" button on GitHub, we do a local merge, then test, then push.  
 
-See [github help on merging a pull-request](https://help.github.com/articles/merging-a-pull-request)
+See [GitHub help on merging a pull-request](https://help.github.com/articles/merging-a-pull-request)
 
-The github page for the pull-request will provide you the right commands to do the local merge, similar to the following.
+The GitHub page for the pull-request will provide you the right commands to do the local merge, similar to the following.
 
 Get the changes from that branch to a new local branch:
 

--- a/web-style.md
+++ b/web-style.md
@@ -87,3 +87,18 @@ The recess command is provided by sugar-build.
 To check CSS or LESS code:
 
     recess css/activity.css -noIDs false -noOverqualifying false
+
+### Karma
+
+If you are hacking on sugar-web, run the testsuit with the *karma* command inside a osbuild shell:
+
+    karma start sugar-web/test/karma.conf.js
+
+We encourage writting new unit tests for new features.
+
+After you do the changes, run:
+
+    check
+
+It will run all the code checks and the unit tests making sure you won't break the build when your changes are pushed. 
+If a test doesn't pass either your code needs to be fixed or the test need to be adapted.


### PR DESCRIPTION
A discussion starter for a few changes following a brief meeting on IRC between @i5o, @walterbender, and @quozl.

Please see individual commit messages.  Further commits may be added and the series rebased.

See the [changes in context](https://github.com/quozl/sugar-docs/blob/2016-357-pull-requests/contributing.md).

By the way, GitHub on the sugar-docs repository says "*Please review the guidelines for contributing to this repository.*", but other repositories do not; there's a latent opportunity to set this feature on the other repositories.