### PR TITLE
Fix broken links in doc page 

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -31,8 +31,7 @@ Contributing images
 
 * Make them 600px width, or less.
 
-* You may need to highlight parts of the image.  Use color yellow (rgb
-  255, 255, 0) at 30% opacity, in a layer with Multiply mode, over the
+* You may need to highlight parts of the image.  Use color yellow rgb(255, 255, 0) at 30% opacity, in a layer with Multiply mode, over the
   screenshot layer.
 
 * Code screenshots: use gedit and default GNOME theme to make them.

--- a/index.md
+++ b/index.md
@@ -25,10 +25,10 @@ Design
 
 Sugar Web
 ---------
-
+* [Write your own web activity](web-activity.md.html)
 * [Architecture](web-architecture.md.html)
 * [Web code style](web-style.md.html)
-* [Components documentation](sugar-web/README.md.html)
+* [Components documentation](https://github.com/sugarlabs/sugar-web)
 
 Sugar GTK
 ---------

--- a/what-can-i-do.md
+++ b/what-can-i-do.md
@@ -23,7 +23,7 @@ little while, as people will come and go at different times of the day.
 Some of our developers have elected to be put on the list of mentors.
 You can find the list [here][5].
 
-[1]: activity.md.html
+[1]: https://github.com/sugarlabs/sugar-docs/blob/master/activity.md
 [2]: https://github.com/ignaciouy/sugar-irc/wiki/Top-Ten-Tickets-This-Week
 [3]: http://bugs.sugarlabs.org
 [4]: http://lists.sugarlabs.org/listinfo/sugar-devel


### PR DESCRIPTION
Referring to issue #108 , fixes the Component Documentation link and remove some typo. 
@walterbender @davelab6 to review.