### PR TITLE
Rewrite desktop activity guide

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -14,18 +14,31 @@ In brief, you will:
 * close your issue.
 
 Modifying Activities
------------------
+--------------------
 
-Most activity repositories can be found in our [sugarlabs GitHub organisation](https://github.com/sugarlabs).
+Most activity repositories can be found in our [GitHub `sugarlabs`
+organization](https://github.com/sugarlabs).
 
-A few activity repositories are somewhere else; read the `activity/activity.info` file, check the metadata on the [activities.sugarlabs.org app store](https://activities.sugarlabs.org/), or the [Activity page on wiki.sugarlabs.org](https://wiki.sugarlabs.org/go/Activity), or our deprecated [gitorious instance](https://git.sugarlabs.org/).
+A few activity repositories are somewhere else; read the
+`activity/activity.info` file, check the metadata on the
+[activities.sugarlabs.org app
+store](https://activities.sugarlabs.org/), or the [Activity page on
+wiki.sugarlabs.org](https://wiki.sugarlabs.org/go/Activity), or our
+deprecated [gitorious instance](https://git.sugarlabs.org/).
 
-For new activities, make a new repository in your GitHub account, put the source code in it, then ask the [systems@ list](https://lists.sugarlabs.org/listinfo/systems) to move it to the `sugarlabs` organisation.
+For new activities, see [Write your own Sugar desktop
+activity](desktop-activity.md.html), or [Write your own Sugar web
+activity](web-activity.md.html), then make a new repository in your
+GitHub account, put the source code in it, then ask the [systems@
+list](https://lists.sugarlabs.org/listinfo/systems) to move it to the
+GitHub `sugarlabs` organization.
 
 Modifying Sugar
 ---------------
 
-Sugar repositories can be found in our [sugarlabs GitHub organisation](https://github.com/sugarlabs).  Sugar desktop environment repositories are:
+Sugar repositories can be found in our [GitHub `sugarlabs`
+organization](https://github.com/sugarlabs).  Sugar desktop
+environment repositories are:
 
 * https://github.com/sugarlabs/sugar (the shell);
 * https://github.com/sugarlabs/sugar-artwork (images, icons, themes);

--- a/desktop-activity.md
+++ b/desktop-activity.md
@@ -1,143 +1,161 @@
-Write your own desktop activity
-===============================
+Write your own Sugar desktop activity
+=====================================
 
-While the Sugar desktop can support activites written in a number of
-different languages, including Smalltalk, C, and JavaScript, the
-majority of activities are written in Python and utilize the
-[sugar-toolkit-gtk3](https://github.com/sugarlabs/sugar-toolkit-gtk3)
-libraries. This document describes the basic requirements for
-developing a Python activity.
+Most Sugar desktop activities are written in Python, using our
+[GTK+ 2.0](https://github.com/sugarlabs/sugar-toolkit) or
+[GTK+ 3.0](https://github.com/sugarlabs/sugar-toolkit-gtk3) libraries.
+This page shows how to develop an activity using Python with GTK+ 3.0.
 
-### Setting up the development environment
+Some Sugar desktop activities are written in languages other than
+Python, such as Smalltalk, C, and JavaScript.  For new activities to
+run on both Sugar desktop and Sugarizer, please consider [Write your
+own Sugar web activity](web-activity.md.html).
 
-You should begin by setting up **osbuild**, the Sugar build
-environment (See [Sugar build environment](dev-environment.md.html)).
-**osbuild** provides all of the core libraries you'll need.  And you
-will use it for testing your activity and packaging it for
-distribution.
+### Setting up a development environment
 
-### Create a new activity from a template 
+You must first [setup a development
+environment](dev-environment.md.html), for testing your activity and
+releasing it for distribution.
 
-Once you have set up **osbuild**, locate the **activities** directory
-on your machine. By default, it will be in:
+### Create a new activity from a template
 
-    ~/sugar-build/activities
+Locate the activity directories.  They may include:
 
-Individual activities reside in subdirectories of the `activities`
-directory. This is where you will create your new activity.
+* `~/Activities` for native Sugar desktop, and packaged Sugar desktop on Fedora, Debian or Ubuntu;
+* `/usr/share/sugar/activities` for packaged Sugar desktop; and,
+* `~/sugar-build/activities` for *sugar-build* only.
 
-A quick way to get started it to clone a copy of the Hello World
-Activity from [hello-world](https://github.com/manuq/hello-world.git)
+Each installed activity is in a directory under the activity
+directories.  This is where you will create your new activity.
 
-    git clone https://github.com/manuq/hello-world.git activity-name.activity
+Clone the Hello World activity from
+[hello-world on GitHub](https://github.com/sugarlabs/hello-world-fork):
 
-Note that you must use the `.activity` suffix in the directory name of
-your new activity.
+    git clone https://github.com/sugarlabs/hello-world-fork.git Name.activity
+
+Use the `.activity` suffix in the directory name of an activity,
+because that's the way an activity bundle is released.
 
 ### Customize
 
-Your clone of the Hello World Activity contains a file,
-`activity/activity.info` that you will need to modify.
+Your clone of the Hello World activity contains a file,
+`activity/activity.info`:
 
     [Activity]
     name = HelloWorld
     activity_version = 1
-    bundle_id = org.sugarlabs.MyActivity.HelloWorld
+    bundle_id = org.sugarlabs.HelloWorld
     exec = sugar-activity activity.HelloWorldActivity
     icon = activity-helloworld
     licence = GPLv3+
 
-Choose a name and unique bundle-id for your activity by editing the
-file.
+You must set a new `name` and a unique `bundle_id` for your activity.
 
-Note: Don't use punctuation in your bundle_id, e.g.,
-`org.sugarlabs.my-activity-name` is not a valid bundle name. Instead, use
-CamelCase, e.g., `org.sugarlabs.MyActivityName`.
+Avoid punctuation in your `bundle_id`, e.g.,
+`org.sugarlabs.my-activity-name` is not valid. Instead, use
+CamelCase, e.g., `org.sugarlabs.MyActivity`.
 
     [Activity]
-    name = MyActivityName
+    name = MyActivity
     activity_version = 1
-    bundle_id = org.sugarlabs.MyActivity.MyActivityName
+    bundle_id = org.sugarlabs.MyActivity
     exec = sugar-activity activity.HelloWorldActivity
     icon = activity-helloworld
     licence = GPLv3+
 
-You'll also want to change the `exec` field to reference the name of
-the class in your `activity.py` file, e.g., if you change Line 32:
+You should change the Activity class in your `activity.py` file, e.g., from:
 
     class HelloWorldActivity(activity.Activity):
 
 to:
 
-    class MyActivityActivity(activity.Activity):
+    class MyActivity(activity.Activity):
 
-then you need to change `activity/activity.info` as follows:
+You must change the `exec` field as well, e.g., from:
 
-    [Activity]
-    name = MyActivityName
-    activity_version = 1
-    bundle_id = org.sugarlabs.MyActivity.MyActivityName
-    exec = sugar-activity activity.MyActivityActivity
-    icon = activity-helloworld
-    licence = GPLv3+
+    exec = sugar-activity activity.HelloWorldActivity
+
+to:
+
+    exec = sugar-activity activity.MyActivity
 
 We recommend that you use a GPLv3+ license.
 
-To read more about `activity.info`, see the [Activity
+So your final `activity.info` file will look like:
+
+    [Activity]
+    name = MyActivity
+    activity_version = 1
+    bundle_id = org.sugarlabs.MyActivity
+    exec = sugar-activity activity.MyActivity
+    icon = activity-helloworld
+    licence = GPLv3+
+
+To read more about the `activity.info` file, see [Activity
 Bundles](https://wiki.sugarlabs.org/go/Development_Team/Almanac/Activity_Bundles)
-page in our wiki.
+on our Wiki.
 
-You should make your activity's appearance unique in the Sugar
-interface by changing your activity icon.  (Yoy are welcome to ask for
-help from the community if you don't feel comfortable with graphic
-design.)
+You must make your activity icon unique in the Sugar interface by
+making a new one, or borrowing from another icon and making changes.
+Ask for help from the community if you don't feel comfortable with
+graphic design.
 
-`activity/activity-helloworld.svg`.
+Here is `activity/activity-helloworld.svg`;
 
 ![Activity
- Icon](https://rawgit.com/manuq/hello-world/master/activity/activity-helloworld.svg
+ Icon](images/activity-helloworld.svg
  "Activity icon")
 
-You can rename this file as long as you make the corresponding edit in
-the `actvity.info` file.
+You should rename this file and change `icon` in the `activity.info`
+file.
 
-Note that your activity icon must follow the guidelines as decribed in
+Your activity icon must follow the guidelines as decribed in
 [The Sugar Interface:
-Icons](https://wiki.sugarlabs.org/go/Human_Interface_Guidelines/The_Sugar_Interface/Icons).
+Icons](https://wiki.sugarlabs.org/go/Human_Interface_Guidelines/The_Sugar_Interface/Icons) on our Wiki.
 
 There is a helper script, [Sugar
-Iconify](https://wiki.sugarlabs.org/go/Sugar_iconify) that will help
+Iconify](sugar-iconify.md.html) that will help
 you create Sugar-compliant icons.
 
 Of course, the interesting changes will be the ones you make to the
-activity itself. Below you will find some links to some resources
-regarding some Sugar Activity devolepment details, but perhaps the
+activity itself. Below you will find links to some resources
+on Sugar Activity development, but perhaps the
 best way to get started is to modify an existing activity that has
 features similar to the one you want to create.
 
 ### Running your activity
 
 Launch Sugar and your new activity should be immediately available,
-although since it has not yet been selected as a **favorite**, it will
-not appear by default on the Sugar Home View. You need to select the
-**List View** to see your activity's icon.
+although since it has not yet been selected as a favorite, it will
+not appear by default on the Sugar Home View (F3). You need to either;
 
-Click on your activity icon and, if all goes well, your activity will
-launch.
+* type the name of your activity into the search entry and press enter; or,
+
+* select the List View (ctrl+2) to see your activity, and click on it.
+
+If all goes well, your activity will launch.
 
 There are many opportunities to make mistakes. Don't get discouraged,
-as engaging in debugging is a great way to learn. One useful tool is
-the Log Activity, which will show you the log files of the system and
-individual activities. Alternatively, you can look at the log files
+as debugging is a great way to learn. One useful tool is the Log
+Activity, which will show you the log files of the operating system,
+Sugar and activities. Alternatively, you can look at the log files
 from the command line.
 
-    ~/sugar-build/home/dotsugar/default/logs
+Log files are usually in the directory `~/.sugar/default/logs`.
+
+Log files for *sugar-build* are in the directory `~/sugar-build/home/dotsugar/default/logs`.
+
+Log files are named using the `bundle_id`.
+
+You may also test interactively by starting Terminal, then `cd` to the activity directory, and type:
+
+    sugar-activity .
 
 ### File structure
 
-All activities follow the same basic file structure:
+All activities should follow this file structure:
 
-    my-activity/
+    MyActivity.activity/
     |-- activity/
     |   |-- activity.info
     |   `-- activity-icon.svg
@@ -145,20 +163,20 @@ All activities follow the same basic file structure:
     `-- setup.py
 
 * `activity/` contains information about your activity, including the
-  name, ID, and the icon.
+  `name`, `bundle_id`, and the `icon`.
 
 * `activity.py` contains an instance of the activity class, which is
-  run when your activity is launched.
+   run when your activity is launched.
 
 * `setup.py` lets you install your activity or make an installable
-  bundle with it
+   bundle with it.
 
 ### Translation
 
-Since Sugar serves a global audience, it is important to enable your
+Sugar serves a global audience, so it is important to enable your
 activity for internationalization and localization. A [guide to best
 practices](https://wiki.sugarlabs.org/go/Translation_Team/i18n_Best_Practices)
-is found in our wiki.
+is on our Wiki.
 
 ### Revision control your code
 
@@ -172,27 +190,28 @@ to initialize the repository:
 With [git
 status](https://www.kernel.org/pub/software/scm/git/docs/git-status.html)
 you can show the available files in the folder they are still
-untracked. Now add all the files in the directory besides the lib
-folder and commit those changes, you can use git status again to see
-the current state:
+untracked. Now add all the files in the directory and commit those
+changes, you can use git status again to see the current state:
 
     git add .
     git commit -a -m 'Initial import'
     git status
 
 We recommend that you use [github](http://github.com) to host your
-Sugar Activity.
+activity.
 
 ### Ready to release
 
-Once your activity is working, you can request to have
+Once your activity is working, you can ask to have
 your activity repository hosted under the [Sugar Labs github
-account](http://github.com/sugarlabs).
+organization](http://github.com/sugarlabs).
 
-From **osbuild** you can make an XO bundle and upload it to
-the Sugar activities portal <http://activities.sugarlabs.org/> .
+Make an XO bundle and upload it to
+the Sugar Activity Library <http://activities.sugarlabs.org/> (ASLO).
 
     python setup.py dist_xo
+
+After that, users of Sugar can download and install your activity.
 
 For further releases, you should update the activity_version in
 `activity/activity.info`.
@@ -200,13 +219,13 @@ For further releases, you should update the activity_version in
 More details
 ============
 
-Documentation for `sugar-toolkit-gtk3` is available
+Documentation for our GTK+ 3.0 toolkit `sugar-toolkit-gtk3` is available
 [here](https://developer.sugarlabs.org/sugar3/).
 
-A Python-GTK3 tutorial is available
+A Python GTK+ 3.0 tutorial is available
 [here](http://python-gtk-3-tutorial.readthedocs.io/en/latest/).
 
-You may follow this book by James Simmons on how to make Sugar
+You may read this book by James Simmons on how to make Sugar
 activities, available at [Make Your Own Sugar Activities](https://flossmanuals.net/make-your-own-sugar-activities/).
 
 # Coding standards

--- a/dev-environment.md
+++ b/dev-environment.md
@@ -1,12 +1,61 @@
+Sugar is made of several modules and depends on many other libraries.
+
 There are several ways to set up the Sugar environment for doing Sugar
-development. If your goal is to create or modify a Sugar activity, you
-may want to consider installing a [pre-packaged Sugar
-environment](#PACKAGEDSTYLE). Experts may want to create a [native
-Sugar build](#NATIVESTYLE) and install the necessary dependencies by
-hand.
+development:
+
+* for writing or changing a Sugar activity, install a [pre-packaged Sugar
+  environment](#PACKAGED), which will install dependencies automatically;
+
+* for packaging Sugar, downstream developers create a [native Sugar
+  build](#NATIVE) and install the necessary dependencies by hand; or,
+
+* for changing the Sugar desktop and toolkit, developers may use a
+  [`sugar-build` chroot], which tries to install dependencies
+  automatically.
+
+<a name="PACKAGED">
+
+Setup a development environment - packaged style
+================================================
+
+For development of activities without making changes to Sugar desktop.
+
+Install Debian and track `stretch` or `testing`, or install Ubuntu 17.04.
+
+Install the `sucrose` package;
+
+    sudo apt install sucrose
+
+Log out, then log in with the Sugar desktop selected.
+
+Or, install `xrdp` and `rdesktop` then log in to Sugar in a window;
+
+    sudo apt install xrdp rdesktop
+    sudo adduser guest
+    echo sugar | sudo tee -a /home/guest/.xsession
+    rdesktop -g 1200x900 -u guest -p guest 127.0.0.1
+
+<a name="NATIVE">
+
+Setup a development environment - native style
+==============================================
+
+For experts.
+
+Clone each of the sugar, sugar-artwork, sugar-datastore, and
+sugar-toolkit-gtk3 repositories, then in each;
+
+    make
+    sudo make install
+
+You will need to install any dependencies by hand. There are many
+dependencies. A good list of dependencies is the Fedora packaging or
+Debian packaging files.
+
+<a name="CHROOT">
 
 Setup a development environment - chroot style
-===============================
+==============================================
 
 Sugar is made of several modules and sometimes depends on libraries
 which have not yet been packaged in Linux distributions. To make it
@@ -308,39 +357,3 @@ language='sh'>build/logs</code></pre>
 Log files for Sugar and Sugar activities are found in <pre><code
 language='sh'>home/dotsugar/default/logs</code></pre>
 
-<a name="PACKAGEDSTYLE">
-Setup a development environment - packaged style
-===============================
-
-For development of activities without making changes to Sugar desktop.
-
-Install Debian and track `stretch` or `testing`, or install Ubuntu 17.04.
-
-Install the `sucrose` package;
-
-    sudo apt install sucrose
-
-Log out, then log in with the Sugar desktop selected.
-
-Or, install `xrdp` and `rdesktop` then log in to Sugar in a window;
-
-    sudo apt install xrdp rdesktop
-    sudo adduser guest
-    echo sugar | sudo tee -a /home/guest/.xsession
-    rdesktop -g 1200x900 -u guest -p guest 127.0.0.1
-
-<a name="NATIVESTYLE">
-Setup a development environment - native style
-===============================
-
-For experts.
-
-Clone each of the sugar, sugar-artwork, sugar-datastore, and
-sugar-toolkit-gtk3 repositories, then in each;
-
-    make
-    sudo make install
-
-You will need to install any dependencies by hand. There are many
-dependencies. A good list of dependencies is the Fedora packaging or
-Debian packaging files.

--- a/images/activity-helloworld.svg
+++ b/images/activity-helloworld.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
+	<!ENTITY stroke_color "#010101">
+	<!ENTITY fill_color "#FFFFFF">
+]>
+<svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px">
+  <g display="block" id="activity-helloworld">
+    <path d="M9.263,48.396c0.682,1.152,6.027,0.059,8.246-1.463   c2.102-1.432,3.207-2.596,4.336-2.596c1.133,0,12.54,0.92,20.935-5.715c7.225-5.707,9.773-13.788,4.52-21.437   c-5.252-7.644-13.832-9.08-20.878-8.56C16.806,9.342,4.224,16.91,4.677,28.313c0.264,6.711,3.357,9.143,4.922,10.703   c1.562,1.566,4.545,1.566,2.992,5.588C11.981,46.183,8.753,47.522,9.263,48.396z" display="inline" fill="&fill_color;" stroke="&stroke_color;" stroke-width="3.5"/>
+  </g>
+  <circle cx="27.375" cy="27.5" r="19.903"
+     transform="matrix(0.6,0,0,0.6,10.95,11)"
+     id="circle4" fill="&fill_color;" stroke="&stroke_color;" stroke-width="3.5" display="inline" />
+  <g transform="matrix(0.6,0,0,0.6,10.95,11)" id="g6" style="display:inline">
+    <path d="m 27.376,7.598 c 0,0 -11.205,8.394 -11.205,19.976 0,11.583 11.205,19.829 11.205,19.829"
+       id="path8" fill="&fill_color;" stroke="&stroke_color;" stroke-width="3.5" />
+    <path d="m 27.376,7.598 c 0,0 11.066,9.141 11.066,19.976 0,10.839 -11.066,19.829 -11.066,19.829"
+       id="path10" fill="&fill_color;" stroke="&stroke_color;" stroke-width="3.5" />
+    <line x1="27.375999" x2="27.375999" y1="7.598" y2="47.402"
+       id="line12" fill="&fill_color;" stroke="&stroke_color;" stroke-width="3.5" />
+    <line x1="27.375999" x2="27.375999" y1="7.598" y2="47.402"
+       id="line14" fill="&fill_color;" stroke="&stroke_color;" stroke-width="3.5" />
+    <line x1="27.375999" x2="27.375999" y1="7.598" y2="47.402"
+       id="line16" fill="&fill_color;" stroke="&stroke_color;" stroke-width="3.5" />
+    <line x1="7.4720001" x2="47.278" y1="27.5" y2="27.5"
+       id="line18" fill="&fill_color;" stroke="&stroke_color;" stroke-width="3.5" />
+  </g>
+</svg>

--- a/index.md
+++ b/index.md
@@ -1,8 +1,8 @@
 Introduction
 ============
 
-Welcome to the Sugar developers site. 
-Here you will find all you need to get started and contribute to Sugar. 
+Welcome to the Sugar developers site.
+Here you will find all you need to get started and contribute to Sugar.
 You can also help us [improve this documentation](docs.md.html).
 
 Getting started
@@ -15,16 +15,17 @@ Design
 ------
 * [Human Interface Guidelines](HIG.md.html)
 * [Components showcase](http://sugarlabs.github.io/sugar-web-samples/)
-* [Sugar Iconify](sugar-iconify.md)
+* [Sugar Iconify](sugar-iconify.md.html)
+
 Sugar Desktop
----------
+-------------
 * [Setup a development environment](dev-environment.md.html)
-* [Write your own desktop activity](desktop-activity.md.html)
+* [Write your own Sugar desktop activity](desktop-activity.md.html)
 * [Python code style](python-style.md.html)
 
 Sugar Web
 ---------
-* [Write your own web activity](web-activity.md.html)
+* [Write your own Sugar web activity](web-activity.md.html)
 * [Architecture](web-architecture.md.html)
 * [Web code style](web-style.md.html)
 * [Components documentation](sugar-web/README.md.html)

--- a/sugar-iconify.md
+++ b/sugar-iconify.md
@@ -12,12 +12,11 @@ It will create Sugar-compatible SVG icons from an ```input.svg``` by
 adding the appropriate stroke and fill entities. It can be used to
 convert a single icon or run over a batch of icons at one time.
 
-You can find the script in the [sugariconify repository](
-https://github.com/GhostAlgorithm/sugariconify/blob/master/sugariconify.py).
- 
-Note that there is a web service available for converting icons as
+You can find the script in the [sugariconify repository](https://github.com/GhostAlgorithm/sugariconify/blob/master/sugariconify.py).
+
+There is a web service available for converting icons as
 well (See [Sugar Iconify Service](http://kuckuck.treehouse.su:5000/)).
- 
+
 For additional information about creating an SVG suitable for Sugar,
 see the tutorial on [Making Sugar
 Icons](http://wiki.laptop.org/go/Making_Sugar_icons).

--- a/web-activity.md
+++ b/web-activity.md
@@ -1,34 +1,46 @@
-Write your own web activity
-===========================
+Write your own Sugar web activity
+=================================
 
 ### Choose your development environment
 
-You've got two choices to develop your own web activity for Sugar:
+You've got three choices to develop your own web activity for Sugar:
 
-- Using osbuild
-- Using Sugarizer
+- install packaged Sugar on Fedora, Debian, or Ubuntu; or,
+- use *sugar-build*;
+- use Sugarizer.
 
-**osbuild** is the Sugar build environment. With **osbuild** you've got a full Sugar environment. It's the better choice if you've enough knowledge to build your environment on GNU Linux.
+*sugar-build* is a Sugar desktop build environment. With *sugar-build*
+you've got a full Sugar desktop environment. It's a good choice if
+you've enough knowledge to build your environment on GNU Linux.
 
-**Sugarizer** simulate the Sugar environment in a browser. So you need only a browser to start developing. It's the better choice if you've no time or knowledge to learn how to build Sugar on a GNU Linux distribution but you're not exactly in a real Sugar environment.
+See [Setup a development environment](dev-environment.md.html) for
+more detail.
 
-### Create the activity from the template 
+*Sugarizer* simulates the Sugar environment in a browser. So you need
+only a browser to start developing. It's the better choice if you've
+no time or knowledge to learn how to install or build Sugar desktop
+on a GNU Linux distribution but you're not in a Sugar desktop
+environment, so your activity may only work in Sugarizer.
 
-On **osbuild**, after you have [built](dev-environment.md.html) the development
-environment, enter the sugar-build shell
+### Create the activity from the template
+
+On *sugar-build*, after you have built the development
+environment, enter the shell
 
     ./osbuild shell
-
 
 Create an activity based on the default template
 
     volo create my-activity ./sugar-web-template
     cd my-activity
 
-On **Sugarizer**, after you've cloned - or copied - the [Sugarizer repository](https://github.com/llaske/Sugarizer), copy all content of `activities/ActivityTemplate` directory in a new directory `activities/MyActivity.activity`.
-
+On *Sugarizer*, after you've cloned - or copied - the [Sugarizer
+repository](https://github.com/llaske/Sugarizer), copy all content of
+`activities/ActivityTemplate` directory in a new directory
+`activities/MyActivity.activity`.
 
 ### Customize
+
 Choose a name for your activity.  Write it in the activity name and
 bundle-id in `activity/activity.info` of the new directory.
 
@@ -38,12 +50,11 @@ And also in the title tag of `index.html`.
 
 ![index.html](images/activity-html.png "index.html")
 
-
-On **osbuild**, install the activity for development
+On *sugar-build*, install the activity for development
 
     python setup.py dev
 
-On **Sugarizer**, update the file `activities.json` of the Sugarizer directory: add a new line for your activity. Update id, name and directory values on this new line.
+On *Sugarizer*, update the file `activities.json` of the Sugarizer directory: add a new line for your activity. Update id, name and directory values on this new line.
 
 ![Sugarizer settings](images/sugarizer-json.png "Sugarizer settings")
 
@@ -95,7 +106,7 @@ Those are the files you'll modify in most cases. The others are:
   bundle with it
 
 Now you are ready to go ahead and develop your activity in the html,
-js and css files.
+js and css directories.
 
 ### Revision control your code
 
@@ -232,9 +243,9 @@ The activity depends on the
 [sugar-web](http://github.com/sugarlabs/sugar-web) library
 that provides the Sugar API and the Sugar look & feel.
 
-This means that if there are changes to the library you have to update your
-local copy. You can do this (on **osbuild** only) with running the following command inside the
-activity directory:
+This means that if there are changes to the library you have to update
+your local copy. You can do this (on *sugar-build* only) with running
+the following command inside the activity directory:
 
     volo add -f
 
@@ -268,18 +279,11 @@ Before your first release, you should:
   activity icon activity/activity-icon.svg .  Or if you don't have
   graphics skills, you can ask in the community if someone can do it.
 
-After that, on **osbuild** you can make an XO bundle and upload it to the Sugar
-activities market <http://activities.sugarlabs.org/> .
+After that, on *sugar-build* you can make an XO bundle and upload it to the Sugar Activity Library <http://activities.sugarlabs.org/> (ASLO).
 
     python setup.py dist_xo
 
-With **Sugarizer**, you can directly publish the XO bundle. So, just zip the content of your `activities/MyActivity.activity` directory and rename the `.zip` file to a `.xo` file.
+With *Sugarizer*, you can directly publish the XO bundle. So, just zip the content of your `activities/MyActivity.activity` directory and rename the `.zip` file to a `.xo` file.
 
 For further releases, you should update the activity_version in
 `activity/activity.info`.
-
-Writing python activities
-===========================
-You may follow this book by James Simmons on how to make Sugar activities, available at  
-
-https://flossmanuals.net/make-your-own-sugar-activities/


### PR DESCRIPTION
- modernise desktop activity guide, include activity icon in this repository,

- several fixes in contributing guide, mentioned by Walter,

- re-order development environment guide, put packaged style first as it
  is working well at the moment,

- fix bad link to Sugar Iconify guide,

- refer to sugar-build rather than osbuild in web activity guide.

(note: includes #120).