### PR TITLE
adding code of conduct from wiki

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,141 @@
+Code of Conduct
+===============
+
+To be effective, the members of the Sugar Labs community must to work
+together; our code of conduct lays down the "ground rules" for our
+cooperative efforts.
+
+The Sugar Labs community supports the educators and software
+developers who use and develop the Sugar Learning Platform. Sugar is a
+place for children to explore, learn, teach, and reflect. Sugar Labs
+is a place where we all can explore, learn, teach, and reflect. The
+same underlying principles that make Sugar great—discovery,
+collaboration, and reflection—are central to the way the Sugar
+community operates.
+
+We chose the name Sugar Labs, plural, because we are more than one
+lab, one person, or one idea. Plurality captures the spirit of
+sharing, cooperation, and criticism that is at the heart of the free
+software/open-source movement. We collaborate freely on a volunteer
+basis to build software for everyone's benefit. We improve on the work
+of others, which we have been given freely, and then share our
+improvements on the same basis.
+
+That collaboration depends on good relationships between developers
+(and end-users). We have agreed upon the following Code of Conduct as
+a guide to our collaboration and cooperation.
+
+This Code of Conduct covers your behavior as a member of the Sugar
+Labs community, in any forum, mailing list, wiki, web site, IRC
+channel, code-sprint, public meeting, or private correspondence. The
+Oversight Board will arbitrate in any dispute over the conduct of a
+member of the community.
+
+Be considerate
+--------------
+
+Your work will be used by other people, and you in turn will depend on
+the work of others. Any decision you take will affect users and
+colleagues, and we expect you to take those consequences into account
+when making decisions. For example, when we are in a feature freeze,
+please don't upload dramatically new versions of critical system
+software, as other people will be testing the frozen system and not be
+expecting big changes.
+
+Be respectful
+-------------
+
+The Sugar Labs community and its members treat one another with
+respect. Everyone can make a valuable contribution to Sugar. We may
+not always agree, but disagreement is no excuse for poor behavior and
+poor manners. We might all experience some frustration now and then,
+but we cannot allow that frustration to turn into a personal
+attack. It's important to remember that a community where people feel
+uncomfortable or threatened is not a productive one. We expect members
+of the Sugar community to be respectful when dealing with other
+contributors as well as with people outside the Sugar project, and
+with users of Sugar.
+
+Be collaborative
+----------------
+
+Sugar Labs and Free Software are about collaboration and working
+together. Collaboration reduces redundancy of work done in the Free
+Software world, and improves the quality of the software produced. You
+should aim to collaborate with other Sugar contributors, as well as
+with the entire Sugar ecosystem that is interested in the work you
+do. Your work should be done transparently and patches from Sugar
+should be given back to the community when they are made, not just
+when the distribution releases. If you wish to work on new code for
+existing upstream projects, at least keep those projects informed of
+your ideas and progress. It may not be possible to get consensus from
+upstream or even from your colleagues about the correct implementation
+of an idea, so don't feel obliged to have that agreement before you
+begin, but at least keep the outside world informed of your work, and
+publish your work in a way that allows outsiders to test, discuss and
+contribute to your efforts.
+
+Be flexible
+-----------
+
+The Sugar Labs community and its members come from various backgrounds
+and cultures.  It is important to remember that Sugar Labs is a place
+for educators and developers; parents, teachers, and children; and
+speakers of many languages to work together.  Try to find the
+appropriate forum for your topic, level or expertises, or language.
+If you come across a post that is in an incorrect forum, please
+respectfully redirect the poster to the appropriate.  However, a
+project such as Sugar Labs requires communication between groups and
+languages.
+
+When you disagree, consult others
+---------------------------------
+
+The Sugar community is not immune to disagreements—both political and
+technical. We do not try to avoid disagreements or differing views,
+but we do try to resolve them constructively. Turn to the community
+and to community processes to seek advice and to mediate and resolve
+disagreements. Community resources include an Oversight Board which
+will help to decide the right course for Sugar Labs, project teams and
+team leaders who may be able to help you, and an ombudsman who will
+investigate complaints and, where possible, resolve them by making
+recommendations to the community. We welcome you to fork the Sugar
+code base if you are determined to go your own way; enabling the
+community to test your ideas and possibly merge them back into the
+mainstream.
+
+When you are unsure, ask for help
+---------------------------------
+
+Nobody knows everything, and nobody is expected to be perfect in the
+Sugar community. Asking questions avoids many problems down the road,
+and so questions are encouraged. Those who are asked should be
+responsive and helpful. However, when asking a question, care must be
+taken to do so in an appropriate forum.
+
+Step down considerately
+-----------------------
+
+Developers on every project come and go and Sugar Labs is no
+different. When you leave or disengage from the project, in whole or
+in part, we ask that you do so in a way that minimizes disruption to
+the project. This means you should tell people you are leaving and
+take the proper steps to ensure that others can pick up where you
+leave off.
+
+Mailing lists and web forums
+----------------------------
+
+This code of conduct applies very much to your behavior in mailing
+lists and web forums.
+
+* Please watch your language.  The Sugar community is a family-friendly place.
+* Please use a valid email address to which direct responses can be made.
+* Please avoid flamewars, trolling, personal attacks, and repetitive arguments.
+
+The Sugar Labs Code of Conduct is based on the [Ubuntu Code of
+Conduct](http://www.ubuntu.com/community/conduct). It is licensed
+under the Creative Commons Attribution-Share Alike 3.0 license. You
+may re-use it for your own project, and modify it as you wish, just
+please allow others to use your modifications and give credit to the
+Ubuntu Project!


### PR DESCRIPTION
It would be a useful reminder to our community to have our code of conduct from the wiki available here.