### PR TITLE
Update dev-environment.md for building on Fedora

### DIFF
--- a/dev-environment.md
+++ b/dev-environment.md
@@ -131,6 +131,7 @@ done
 ```
 
 On Fedora, use [dnf builddep](http://dnf-plugins-core.readthedocs.io/en/latest/builddep.html), like this;
+(If you are using GNOME's desktop environment, make sure you are using GNOME Xorg before moving forward!)
 
 ```
 for module in sugar{-datastore,-artwork,-toolkit,-toolkit-gtk3,}; do


### PR DESCRIPTION
Without using GNOME Xorg I couldn't build the project. The logs didn't provide anything useful in this sense. I spent about 15 hours trying to build Sugar on Fedora. I hope no one ever has to go through this. Thanks to Gonzalo Odiard for suggesting me to use GNOME Xorg.