### PR TITLE
don't ask permission

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -13,6 +13,14 @@ In brief, you will:
 * go through the review process until your pull-request is merged; and
 * close your issue.
 
+Please note there is no need to ask permission to work on an
+issue. You should check for pull requests linked to the issue you are
+addressing; if there are none, then it is safe to assume that no one
+else is working on it.  Mention the issue number in your pull request,
+but not in your commit messages. These practices keep the git history
+independent of the external GitHub Issues management system and also
+allow the competition of ideas (Sugar Labs is a meritocracy).
+
 Modifying Activities
 --------------------
 


### PR DESCRIPTION
In order to combat the recent trend to ask permission to work on an issue, I have added a paragraph that explains that this is neither required or desired.  I also mention that issue numbers should be mentioned in PRs, but not in the commit messages. The language is loosely based on [Quozl's comment](https://github.com/sugarlabs/www-sugarlabs/issues/181#issuecomment-376027257).
