### PR TITLE
Avoid activities.sugarlabs.org for Python 3 bundles

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -57,7 +57,8 @@ After modifying an activity, a new release may be needed.  Some activities have 
 
 ### Checklist - maintainer
 
-* [ ] check version of latest bundle release in [activities.sugarlabs.org](https://activities.sugarlabs.org/),
+* [ ] for Python 2 branches, check version of latest bundle release in
+  [activities.sugarlabs.org](https://activities.sugarlabs.org/),
 
 * [ ] check version of latest tarball release in [download.sugarlabs.org/sources/sucrose/fructose/](https://download.sugarlabs.org/sources/sucrose/fructose/) or [download.sugarlabs.org/sources/honey/](https://download.sugarlabs.org/sources/honey/),
 
@@ -91,9 +92,15 @@ After modifying an activity, a new release may be needed.  Some activities have 
 
 * [ ] for activities that include a tarball release, or where Fedora or Debian packages may be made, create a tarball using `python setup.py dist_source`, and upload tarball to download.sugarlabs.org using shell account,
 
-* [ ] create bundle using `python setup.py dist_xo`, test that it can be installed by Browse, and upload to activities.sugarlabs.org using developer account,
+* [ ] create bundle using `python setup.py dist_xo`, and test that it
+  can be installed by Browse,
 
-* [ ] rebase any other maintained branches or pull requests, such as those for future versions of Python, or past releases of Fedora, Ubuntu or libraries.
+* [ ] for Python 2 branches only, upload to activities.sugarlabs.org
+  using developer account,
+
+* [ ] rebase any other maintained branches or pull requests, such as
+  those for past or future versions of Python, or past releases of
+  Fedora, Ubuntu or libraries.
 
 
 Modifying Sugar

--- a/src/desktop-activity.md
+++ b/src/desktop-activity.md
@@ -205,14 +205,15 @@ Once your activity is working, you can ask to have
 your activity repository hosted under the [Sugar Labs github
 organization](http://github.com/sugarlabs).
 
-Make an XO bundle and upload it to
-the Sugar Activity Library <http://activities.sugarlabs.org/> (ASLO).
+Make an XO bundle.
 ```
 python setup.py dist_xo
 ```
+And if it works with Python 2 then upload it to the Sugar Activity
+Library <http://activities.sugarlabs.org/>.
 After that, users of Sugar can download and install your activity.
 
-For further releases, you should update the activity_version in
+For further releases, you must update the activity_version in
 `activity/activity.info`.
 
 More details

--- a/src/how-can-i-help.md
+++ b/src/how-can-i-help.md
@@ -81,7 +81,6 @@ Coding, documentation and quality assurance is important - it is required everyw
   * You can go to a specific GitHub repository and work on the bugs in the source code.  Choose the "Issues" tabs and work through the various issues listed in it. The main Sugar Labs GitHub Repositories are listed in the "Important Sugar Labs Links".
   * You can write documentation, see the [Wiki](https://wiki.sugarlabs.org), the [Help Activity](http://wiki.sugarlabs.org/go/Activities/Help/Contribute) which is kept in the [Help](https://github.com/godiard/help-activity) repository, and this [developer documentation](docs.md).
   * You can update web sites, see [www.sugarlabs.org](https://www.sugarlabs.org/) which is kept in the [www-sugarlabs](https://github.com/sugarlabs/www-sugarlabs) repository.
-  * You can monitor [activities.sugarlabs.org](https://activities.sugarlabs.org/) for activities to download in Sugar.
   * You can choose to write your own [desktop activity][1] or write your own [web activity][5].
   * You can port activities which are in GTK+ 2 to GTK+ 3, using the [guide](gtk3-porting-guide.md).
   * You can port activities which are in Python 2 to Python 3, using the [guide](python-porting-guide.md).

--- a/src/languages.md
+++ b/src/languages.md
@@ -31,7 +31,8 @@ different programming languages and libraries;
 
 ## PHP
 
-* activities.sugarlabs.org, the activity store,
+* activities.sugarlabs.org, the activity store for Python 2 and web
+  activities compatible with Sugar 0.112 and earlier,
 
 ## C#
 

--- a/src/web-activity.md
+++ b/src/web-activity.md
@@ -275,7 +275,9 @@ Before your first release, you should:
   activity icon activity/activity-icon.svg .  Or if you don't have
   graphics skills, you can ask in the community if someone can do it.
 
-After that, on *packaged-sugar* you can make an XO bundle and upload it to the Sugar Activity Library <http://activities.sugarlabs.org/> (ASLO).
+After that, if the activity works with Sugar 0.112 or earlier, on
+*packaged-sugar* you may make a bundle and upload it to the Sugar
+Activity Library <http://activities.sugarlabs.org/>.
 
     python setup.py dist_xo
 


### PR DESCRIPTION
Restrict activities.sugarlabs.org to Python 2, JavaScript, and activities compatible with Sugar 0.112.

Sugar 0.113 adds Python 3 toolkit support, which enables porting of Python 2 activities to Python 3.  Yay.

Activities written with Python 3 will *not work* on Sugar 0.112 and earlier.

Automatic update in all currently released versions of Fedora SoaS, and manual update using My Setting - Software Update in Fedora, Debian, and Ubuntu, will *break an activity* if a bundle is released.

Sugar Activity Library is coded to not offer activities for incompatible versions of Sugar, but the feature is [**not working**](https://github.com/sugarlabs/sugar/issues/818).

Oversight board has *not decided* to extend security maintenance of activities.sugarlabs.org.