### PR TITLE
Add links to help newcomers use IRC

### DIFF
--- a/src/contact.md
+++ b/src/contact.md
@@ -4,4 +4,11 @@ Contact
 Join us at Sugar-devel mailing list
 <http://lists.sugarlabs.org/listinfo/sugar-devel>.
 
-We also have an IRC channel. Please enter #sugar at Freenode.
+We also have an [IRC channel][IRC]. Please enter #sugar at
+[Freenode][freenode]. You may wish to begin by using their
+[webchat][webchat].
+
+[IRC]: https://opensource.com/article/16/6/irc-quickstart-guide
+[freenode]: https://freenode.net/
+[webchat]: https://webchat.freenode.net/
+


### PR DESCRIPTION
I added three links: 

the first is to VM Brasseur's quickstart guide, hosted by opensource.com.

The next is to freenode's main page.

The third is to the freenode-hosted KiwiIRC webchat instance.

My hope is that this will help newcomers to the project and to the channel.

