### PR TITLE
Fixed some typos in the documentation

### DIFF
--- a/src/web-activity.md
+++ b/src/web-activity.md
@@ -161,7 +161,7 @@ toolbar button in the previous section, is very limited.  You'll want
 to add HTML elements on the fly, as the user interacts with the
 activity, or as the data structures of your activity logic change.
 There are several options to archive this.  Most of the time you'll
-end using a mix of them, so is important to know them all.
+end up using a mix of them, so it is important to know them all.
 
 First, it is possible to create HTML elements and append them to other
 HTML elements using JavaScript.  This is called "manipulating the

--- a/src/web-architecture.md
+++ b/src/web-architecture.md
@@ -47,7 +47,7 @@ opens a chrome-less window with a WebKitGTK view, and the web activity
 is loaded inside.
 
 The JavaScript interface to connect web activities and Sugar GTK is
-being developed.  The interface ends calling the same bits than GTK
+being developed.  The interface ends up calling the same bits as GTK
 activities.  It uses WebSockets for the communication between
 JavaScript and Python code.
 
@@ -87,7 +87,7 @@ for which the shell has an Intent filter that matches.
 
 The Sugar shell on Android should implement all of the Sugar features,
 unlike Sugar GTK shell that only needs to connect to the current
-features.  But both take adventage of sharing the same JavaScript
+features.  But both take advantage of sharing the same JavaScript
 interface.  The interface should be platform agnostic.
 
 ### Web activities standalone

--- a/src/web-style.md
+++ b/src/web-style.md
@@ -43,7 +43,7 @@ To check CSS or LESS code:
 
 ### Karma
 
-If you are hacking on sugar-web, run the testsuit with the *karma* command inside a osbuild shell:
+If you are hacking on sugar-web, run the test suite with the *karma* command inside a osbuild shell:
 
     karma start sugar-web/test/karma.conf.js
 


### PR DESCRIPTION
### Fixed some typos in the documentation related to [Sugar Web](https://github.com/sugarlabs/sugar-docs#sugar-web)
in [web-activity.md](https://github.com/sugarlabs/sugar-docs/blob/master/src/web-activity.md), [archticture.md](https://github.com/sugarlabs/sugar-docs/blob/master/src/web-architecture.md), [web-style.md](https://github.com/sugarlabs/sugar-docs/blob/master/src/web-style.md)