### PR TITLE
Fix(music-docs): Resolve broken links in Music Blocks subheading

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Welcome to documentation for contributors and developers.
 ## Music Blocks
 
 * [Overview](https://github.com/sugarlabs/musicblocks#readme)
-* [Programming with Music Blocks](https://github.com/sugarlabs/musicblocks/blob/master/guide/README.md)
-* [Using Music Blocks](https://github.com/sugarlabs/musicblocks/blob/master/documentation/README.md)
+* [Programming with Music Blocks](https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md)
+* [Using Music Blocks](https://github.com/sugarlabs/musicblocks/blob/master/Docs/documentation/README.md)
 * [Running Music Blocks](https://github.com/sugarlabs/musicblocks#running-music-blocks)
 * [Contributing](https://github.com/sugarlabs/musicblocks?tab=readme-ov-file#CONTRIBUTING)
 


### PR DESCRIPTION
## 📝 Description

This PR addresses the issue of broken URLs within the Music Blocks sub-heading of the general documentation.

The previous links were leading to 404 "Page Not Found" errors. This commit updates the file(s) to point the documentation links to their correct, functional URLs.

This investigation was requested by a maintainer during the review of PR #606 in the `www-v2` repository.

## 🔗 Related Issue

Mention: Requested during review of `sugarlabs/www-v2#606`

## 🔄 Type of Change

- [x] 🐛 **Bug Fix** (Broken links are bugs)
- [x] 📖 **Content Update** (Fixing the documentation text/links)